### PR TITLE
Upgrade to replicon 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,15 @@ description = "High-level networking crate that extends the bevy_replicon crate 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.11.3", default_features = false }
-bevy_replicon = "0.14.0"
+bevy = { version = "0.11", default_features = false }
+bevy_replicon = "0.16"
 serde = "1.0"
 
 bevy_replicon_snap_macros = { path = "macros" }
 
 [dev-dependencies]
 clap = { version = "4.1", features = ["derive"] }
-bevy = { version = "0.11.3", default-features = false, features = [
+bevy = { version = "0.11", default-features = false, features = [
     "bevy_asset",
     "bevy_core_pipeline",
     "bevy_render",

--- a/examples/interpolated.rs
+++ b/examples/interpolated.rs
@@ -50,7 +50,7 @@ impl Plugin for SimpleBoxPlugin {
     fn build(&self, app: &mut App) {
         app.replicate_interpolated::<PlayerPosition>()
             .replicate::<PlayerColor>()
-            .add_client_event::<MoveDirection>(SendPolicy::Ordered)
+            .add_client_event::<MoveDirection>(EventType::Ordered)
             .add_systems(
                 Startup,
                 (
@@ -80,8 +80,8 @@ impl SimpleBoxPlugin {
                 commands.spawn(PlayerBundle::new(SERVER_ID, Vec2::ZERO, Color::GREEN));
             }
             Cli::Server { port } => {
-                let server_channels_config = network_channels.server_channels();
-                let client_channels_config = network_channels.client_channels();
+                let server_channels_config = network_channels.get_server_configs();
+                let client_channels_config = network_channels.get_client_configs();
 
                 let server = RenetServer::new(ConnectionConfig {
                     server_channels_config,
@@ -114,8 +114,8 @@ impl SimpleBoxPlugin {
                 commands.spawn(PlayerBundle::new(SERVER_ID, Vec2::ZERO, Color::GREEN));
             }
             Cli::Client { port, ip } => {
-                let server_channels_config = network_channels.server_channels();
-                let client_channels_config = network_channels.client_channels();
+                let server_channels_config = network_channels.get_server_configs();
+                let client_channels_config = network_channels.get_client_configs();
 
                 let client = RenetClient::new(ConnectionConfig {
                     server_channels_config,

--- a/examples/no_interpolation_or_prediction.rs
+++ b/examples/no_interpolation_or_prediction.rs
@@ -43,7 +43,7 @@ impl Plugin for SimpleBoxPlugin {
     fn build(&self, app: &mut App) {
         app.replicate::<PlayerPosition>()
             .replicate::<PlayerColor>()
-            .add_client_event::<MoveDirection>(SendPolicy::Ordered)
+            .add_client_event::<MoveDirection>(EventType::Ordered)
             .add_systems(
                 Startup,
                 (
@@ -73,8 +73,8 @@ impl SimpleBoxPlugin {
                 commands.spawn(PlayerBundle::new(SERVER_ID, Vec2::ZERO, Color::GREEN));
             }
             Cli::Server { port } => {
-                let server_channels_config = network_channels.server_channels();
-                let client_channels_config = network_channels.client_channels();
+                let server_channels_config = network_channels.get_server_configs();
+                let client_channels_config = network_channels.get_client_configs();
 
                 let server = RenetServer::new(ConnectionConfig {
                     server_channels_config,
@@ -107,8 +107,8 @@ impl SimpleBoxPlugin {
                 commands.spawn(PlayerBundle::new(SERVER_ID, Vec2::ZERO, Color::GREEN));
             }
             Cli::Client { port, ip } => {
-                let server_channels_config = network_channels.server_channels();
-                let client_channels_config = network_channels.client_channels();
+                let server_channels_config = network_channels.get_server_configs();
+                let client_channels_config = network_channels.get_client_configs();
 
                 let client = RenetClient::new(ConnectionConfig {
                     server_channels_config,

--- a/examples/owner_predicted.rs
+++ b/examples/owner_predicted.rs
@@ -52,7 +52,7 @@ impl Plugin for SimpleBoxPlugin {
     fn build(&self, app: &mut App) {
         app.replicate_interpolated::<PlayerPosition>()
             .replicate::<PlayerColor>()
-            .add_client_predicted_event::<MoveDirection>(SendPolicy::Ordered)
+            .add_client_predicted_event::<MoveDirection>(EventType::Ordered)
             .add_systems(
                 Startup,
                 (
@@ -83,8 +83,8 @@ impl SimpleBoxPlugin {
                 commands.spawn(PlayerBundle::new(SERVER_ID, Vec2::ZERO, Color::GREEN));
             }
             Cli::Server { port } => {
-                let server_channels_config = network_channels.server_channels();
-                let client_channels_config = network_channels.client_channels();
+                let server_channels_config = network_channels.get_server_configs();
+                let client_channels_config = network_channels.get_client_configs();
 
                 let server = RenetServer::new(ConnectionConfig {
                     server_channels_config,
@@ -117,8 +117,8 @@ impl SimpleBoxPlugin {
                 commands.spawn(PlayerBundle::new(SERVER_ID, Vec2::ZERO, Color::GREEN));
             }
             Cli::Client { port, ip } => {
-                let server_channels_config = network_channels.server_channels();
-                let client_channels_config = network_channels.client_channels();
+                let server_channels_config = network_channels.get_server_configs();
+                let client_channels_config = network_channels.get_client_configs();
 
                 let client = RenetClient::new(ConnectionConfig {
                     server_channels_config,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@ use std::io::Cursor;
 use bevy::ecs::world::EntityMut;
 use bevy::prelude::*;
 use bevy::ptr::Ptr;
-use bevy::reflect::erased_serde::__private::serde::{Deserialize, Serialize};
 use bevy_replicon::bincode;
 use bevy_replicon::prelude::*;
 use bevy_replicon::renet::transport::NetcodeClientTransport;
@@ -17,6 +16,7 @@ use bevy_replicon::replicon_core::replication_rules::{
 };
 pub use bevy_replicon_snap_macros;
 use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
 
 pub struct SnapshotInterpolationPlugin {
     pub max_tick_rate: u16,
@@ -203,19 +203,8 @@ fn predicted_snapshot_system<T: Component + Interpolate + Clone>(
     mut q: Query<&mut SnapshotBuffer<T>, (Without<Interpolated>, With<Predicted>)>,
     time: Res<Time>,
 ) {
-    for (mut snapshot_buffer) in q.iter_mut() {
+    for mut snapshot_buffer in q.iter_mut() {
         snapshot_buffer.time_since_last_snapshot += time.delta_seconds();
-    }
-}
-
-fn predicted_event_system<T: Event + Clone>(
-    mut event_reader: EventReader<T>,
-    mut history: ResMut<PredictedEventHistory<T>>,
-    tick: Res<RepliconTick>,
-    time: Res<Time>,
-) {
-    for event in event_reader.iter() {
-        history.insert(event.clone(), tick.get(), time.delta_seconds());
     }
 }
 


### PR DESCRIPTION
- Upgrades to bevy_replicon 0.16
- Changes bevy semver to minor version to allow future patches
- Remove unnecessary parentheses


(Note, cargo complains that lib.rs::predicted_event_system() is unused. Is this intentional or should it be registered with add_client_predicted_event?) 