### PR TITLE
add `WinitSettings` resource in the examples

### DIFF
--- a/examples/interpolated.rs
+++ b/examples/interpolated.rs
@@ -6,7 +6,10 @@ use std::{
     time::SystemTime,
 };
 
-use bevy::prelude::*;
+use bevy::{
+    prelude::*,
+    winit::{UpdateMode, WinitSettings},
+};
 use bevy_replicon::prelude::*;
 use bevy_replicon_renet::{
     renet::{
@@ -32,6 +35,15 @@ const MAX_TICK_RATE: u16 = 5;
 fn main() {
     App::new()
         .init_resource::<Cli>() // Parse CLI before creating window.
+        // When you run client and server on the same machine
+        // it results into different deltas
+        // because only deltas from server being used.
+        // You won't have this problem on real server.
+        // Adding this settings fixes the problem.
+        .insert_resource(WinitSettings {
+            focused_mode: UpdateMode::Continuous,
+            unfocused_mode: UpdateMode::Continuous,
+        })
         .add_plugins((
             DefaultPlugins,
             RepliconPlugins.build().set(ServerPlugin {

--- a/examples/no_interpolation_or_prediction.rs
+++ b/examples/no_interpolation_or_prediction.rs
@@ -6,7 +6,10 @@ use std::{
     time::SystemTime,
 };
 
-use bevy::prelude::*;
+use bevy::{
+    prelude::*,
+    winit::{UpdateMode, WinitSettings},
+};
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 
@@ -29,6 +32,15 @@ const MAX_TICK_RATE: u16 = 5;
 fn main() {
     App::new()
         .init_resource::<Cli>() // Parse CLI before creating window.
+        // When you run client and server on the same machine
+        // it results into different deltas
+        // because only deltas from server being used.
+        // You won't have this problem on real server.
+        // Adding this settings fixes the problem.
+        .insert_resource(WinitSettings {
+            focused_mode: UpdateMode::Continuous,
+            unfocused_mode: UpdateMode::Continuous,
+        })
         .add_plugins((
             DefaultPlugins,
             RepliconPlugins.build().set(ServerPlugin {

--- a/examples/owner_predicted.rs
+++ b/examples/owner_predicted.rs
@@ -7,7 +7,10 @@ use std::{
     time::SystemTime,
 };
 
-use bevy::prelude::*;
+use bevy::{
+    prelude::*,
+    winit::{UpdateMode, WinitSettings},
+};
 use bevy_replicon::{client::ServerEntityTicks, prelude::*};
 use bevy_replicon_renet::{
     renet::{
@@ -34,6 +37,15 @@ const MAX_TICK_RATE: u16 = 5;
 fn main() {
     App::new()
         .init_resource::<Cli>() // Parse CLI before creating window.
+        // When you run client and server on the same machine
+        // it results into different deltas
+        // because only deltas from server being used.
+        // You won't have this problem on real server.
+        // Adding this settings fixes the problem.
+        .insert_resource(WinitSettings {
+            focused_mode: UpdateMode::Continuous,
+            unfocused_mode: UpdateMode::Continuous,
+        })
         .add_plugins((
             DefaultPlugins,
             RepliconPlugins.build().set(ServerPlugin {


### PR DESCRIPTION
It fixes the problem when you run server and client on the same machine and only delta from the server is used. Without these settings you may see strange behaviors. For instance, client may have different velocity than server and etc.