### PR TITLE
example wouldn't build - found the culprit!

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -31,7 +31,7 @@ pub fn derive_interpolate(input: TokenStream) -> TokenStream {
         _ => panic!("expected a struct"),
     };
     let output = quote! {
-        impl ::bevy_replicon_snap::interpolation::Interpolate for #ident {
+        impl bevy_replicon_snap::interpolation::Interpolate for #ident {
             fn interpolate(&self, other: Self, t: f32) -> Self {
               #body
             }


### PR DESCRIPTION
An extra :: snuck in! I was getting an error that the "Interpolate" trait wasn't working, kept asking me to import a module, wouldn't recognize the macro, and so on. Took a peek and made this little change, now the example compiles for me. 